### PR TITLE
Fix: Add unity shutdown

### DIFF
--- a/Assets/Plugins/Android/AndroidManifest.xml
+++ b/Assets/Plugins/Android/AndroidManifest.xml
@@ -52,11 +52,6 @@
             android:resizeableActivity="false"
             android:screenOrientation="fullUser"
             android:theme="@style/UnityThemeSelector" >
-            <intent-filter>
-                <category android:name="android.intent.category.LAUNCHER" />
-
-                <action android:name="android.intent.action.MAIN" />
-            </intent-filter>
 
             <meta-data
                 android:name="unityplayer.UnityActivity"

--- a/Assets/Scenes/AR.unity
+++ b/Assets/Scenes/AR.unity
@@ -1325,6 +1325,7 @@ GameObject:
   - component: {fileID: 1689315701}
   - component: {fileID: 1689315703}
   - component: {fileID: 1689315704}
+  - component: {fileID: 1689315705}
   m_Layer: 0
   m_Name: Interaction
   m_TagString: Untagged
@@ -1390,6 +1391,19 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   furniturePool: {fileID: 1890635949}
   arRaycastManager: {fileID: 1563121798}
+--- !u!114 &1689315705
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1689315700}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2c92f05b93e584ddfa17c6899eb5aca3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  quitButton: {fileID: 0}
 --- !u!1 &1890635948
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/FurnitureCollocationButton.cs
+++ b/Assets/Scripts/FurnitureCollocationButton.cs
@@ -12,7 +12,7 @@ public class FurnitureCollocationButton : MonoBehaviour
 {
     [SerializeField]
     GameObject placementIndicator;
-
+    
     public Sprite[] buttonImages;
     public Button button;
     public Transform furniturePool;

--- a/Assets/Scripts/QuitUnity.cs
+++ b/Assets/Scripts/QuitUnity.cs
@@ -1,0 +1,13 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+
+public class QuitUnity : MonoBehaviour
+{
+    private void Update()
+    {
+        if (Input.GetKeyDown(KeyCode.Escape))
+            Application.Quit();
+    }
+}

--- a/Assets/Scripts/QuitUnity.cs.meta
+++ b/Assets/Scripts/QuitUnity.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2c92f05b93e584ddfa17c6899eb5aca3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Settings/FilePathManager.asset
+++ b/Assets/Settings/FilePathManager.asset
@@ -16,4 +16,4 @@ MonoBehaviour:
   albedoTextureName: texture_kd.png
   specularTextureName: texture_ks.png
   normalMapName: texture_n.png
-  filePath: /storage/emulated/0/Download/mesh
+  filePath: /storage/emulated/0/Download


### PR DESCRIPTION
When unity is terminated, Android is alive and only unity is terminated.

Resolves: #36